### PR TITLE
use JavaScript .textContent instead of .innerHTML

### DIFF
--- a/rvk-visual.js
+++ b/rvk-visual.js
@@ -96,11 +96,11 @@ RvkVisual.prototype.prepareLinks = function() {
     // extract notation from tags
     for (var i = 0; i < rvkTags.length; i++) {
         var tagObj = rvkTags[i];
-        var rvkTag = tagObj.innerHTML;
+        var rvkTag = tagObj.textContent;
         rvkTag = rvkTag.replace(/\ /, "+");
-        tagObj.setAttribute("name", tagObj.innerHTML);
+        tagObj.setAttribute("name", tagObj.textContent);
         rvkNotations[rvkTag] = true; // add attribute to object, if it already exists overwrite
-        if (this.debug) console.log("InnerText: " + tagObj.innerHTML);
+        if (this.debug) console.log("InnerText: " + tagObj.textContent);
     }
 
     // requests data from service


### PR DESCRIPTION
Allow building of valid links under heavy conditions. This solution is already mentioned in the GBV Wiki at https://verbundwiki.gbv.de/display/VZG/RVK-VISUAL

.textContent omits any markup decorations provided by some OPAC systems - e.g. "<strong>MR</strong> <strong>2800</strong>" instead of "MR 2800". (Example from Pica OPC4-v2.8.4.9, which will decorate any text matching the search query)